### PR TITLE
Ermöglichung eines sofortigen Vereinsaustritts

### DIFF
--- a/Beitrags_und_Mahnordnung.md
+++ b/Beitrags_und_Mahnordnung.md
@@ -1,18 +1,16 @@
 #Beitrags- und Mahnordnung
 *des Netz39 e.V. - Hackerspace Magdeburg*
 
-in der Fassung vom 06.05.2012
-
-Im Zuge der Gründungsversammlung am 06.05.2012 wurde die Beitrags- und Mahnordnung in der vorliegenden Fassung von der Gründungsversammlung beschlossen
+in der Fassung vom 14.10.2015
 
 ###§1 Beitragsordnung
 1. Der Mitgliedsbeitrag ist jeweils zum Beginn eines Quartals für das gesamte Quartal im Voraus zu entrichten oder kann per Lastschriftverfahren eingezogen werden.
 
 2. Für den Beitritt wird eine Beitrittsgebühr in Höhe von 10,00 € erhoben, die mit dem ersten Beitrag fällig wird.
 
-3. Der Monatsbeitrag beträgt für aktive Mitglieder 30,00 €.
+3. Der Quartalsbeitrag beträgt für aktive Mitglieder 90,00 €.
 
-4. Auf Wunsch eines Mitglieds wird ein ermäßigter Beitragssatz in Höhe von 10,00€ pro Monat gewährt. Dieser Wunsch kann jederzeit beim Schatzmeister für ein Kalenderjahr angezeigt werden. Alle Mitglieder sind angehalten, diese Regelung nur im Bedarfsfall zu nutzen.
+4. Auf Wunsch eines Mitglieds wird ein ermäßigter Beitragssatz in Höhe von 30,00€ pro Quartal gewährt. Dieser Wunsch kann rechtzeitig vor Beginn eines Quartals beim Schatzmeister für ein Kalenderjahr angezeigt werden. Alle Mitglieder sind angehalten, diese Regelung nur im Bedarfsfall zu nutzen.
 
 5. Der Beitrag für Fördermitglieder wird individuell vom Vorstand mit den jeweiligen Fördermitgliedern ausgehandelt und auf der nächsten Mitgliederversammlung bestätigt. Bei natürlichen Personen dienen Abs. 3 und Abs. 4 als Richtlinie.
 

--- a/Beitrags_und_Mahnordnung.md
+++ b/Beitrags_und_Mahnordnung.md
@@ -14,6 +14,8 @@ in der Fassung vom 14.10.2015
 
 5. Der Beitrag für Fördermitglieder wird individuell vom Vorstand mit den jeweiligen Fördermitgliedern ausgehandelt und auf der nächsten Mitgliederversammlung bestätigt. Bei natürlichen Personen dienen Abs. 3 und Abs. 4 als Richtlinie.
 
+6. Der Mitgliedsbeitrag im Eintrittsquartal enfällt. Alle Neumitglieder sind angehalten, einen für sie angemessenen Betrag zu spenden.
+
 ###§2 Mahnordnung
 1. Zwei Wochen nach dem Zahlungstermin (1. Tag des jeweiligen Quartals) des fälligen Mitgliedsbeitrags erfolgt eine Zahlungserinnerung unter Angabe des Zahlungsziels.
 

--- a/Satzung.md
+++ b/Satzung.md
@@ -1,11 +1,11 @@
 #Satzung
 *des Netz39 e.V. - Hackerspace Magdeburg*
 
-in der Fassung vom 24.01.2013
+in der Fassung vom 14.10.2015
 
 Präambel
 --------
-Im folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stand vom 24.01.2013. In diesem Dokument wird der Einfachheit halber ein generisches Maskulinum (z.B. "ein Mitglied") verwendet. Damit sind jedoch stets alle Geschlechter gemeint. An Stellen, an denen schriftliche Kommunikation gefordert wird, ist E-Mail stets mit eingeschlossen.
+Im folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stand vom 14.10.2015. In diesem Dokument wird der Einfachheit halber ein generisches Maskulinum (z.B. "ein Mitglied") verwendet. Damit sind jedoch stets alle Geschlechter gemeint. An Stellen, an denen schriftliche Kommunikation gefordert wird, ist E-Mail stets mit eingeschlossen.
 
 ￼￼Vereinssatzung
 --------------
@@ -43,7 +43,7 @@ Im folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stan
 2. Die Mitgliedschaft beginnt mit der Aushändigung einer entsprechenden Bestätigung durch ein Vorstandsmitglied.
 
 3. Die Mitgliedschaft endet
- -	durch freiwillige Beendigung mit viermonatiger Frist zum Ende des Quartals durch schriftliche Erklärung gegenüber dem Vorstand;
+ -	durch freiwillige Beendigung ohne First durch schriftliche Erklärung gegenüber dem Vorstand;
  -	bei natürlichen Personen durch Tod;
  -	bei juristischen Personen mit Abschluss der Liquidation;
  -	bei Eintritt der Insolvenz des Vereins;

--- a/Satzung.md
+++ b/Satzung.md
@@ -43,7 +43,7 @@ Im folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stan
 2. Die Mitgliedschaft beginnt mit der Aushändigung einer entsprechenden Bestätigung durch ein Vorstandsmitglied.
 
 3. Die Mitgliedschaft endet
- -	durch freiwillige Beendigung ohne First durch schriftliche Erklärung gegenüber dem Vorstand;
+ -	durch freiwillige Beendigung ohne Frist durch schriftliche Erklärung gegenüber dem Vorstand;
  -	bei natürlichen Personen durch Tod;
  -	bei juristischen Personen mit Abschluss der Liquidation;
  -	bei Eintritt der Insolvenz des Vereins;


### PR DESCRIPTION
Dies ist ein Antrag zur Änderung von Satzung und Beitrags Ordnung zur **Mitgliederversammlung am 14.10.2015**
_Der Pull-Request darf natürlich nur nach Abstimmung durch den verein angenommen oder abgelehnt werden._

**Zur Begründung:**
Der Verein hat einmal beschlossen, den Vereinsaustritt erst zum Ende des folgenden Quartals zu ermöglichen, um die Mitgliedsbeiträge innerhalb der Kündigungsfrist der Vereinsräume sicherzustellen.
Mittlerweile hat der Verein genug Rücklagen um einen plötzlichen Massenaustritt der Mitglieder daraus abzufedern. Daher ist die Notwendigkeit der Regelung hinfällig.

Die aktuelle Regelung hat zu mehreren Problemen geführt. Mitglieder die bereits ihren Austrittswunsch geäußert hatten, mussten auch Monate später noch für ein weiteres Quartal aufkommen obwohl sie im Regelfall nichts mehr mit dem Vereinsleben zu tun haben. Dies wirkt sehr negativ auf das austretende Mitglied und wirft ein schlechtes Licht auf den Verein. Der Vorstand war auch in Fällen von finanzieller Not nicht in der Lage diesen Beitrag zu erlassen.
Ein Mitglied welches einen Austrittswunsch äußert, beendet die Mitgliedschaft erst 4-6 Monate später. Ein Mitglied erst nach 4-6 Monaten aus allen Systemen zu nehmen um entsprechende Firsten einzuhalten ist ein erheblicher Mehraufwand in der Mitgliederverwaltung.

**Neue Konstruktion:**
- Ein Vereinsaustritt ist sofort möglich. (Dies spart viel Verwaltungsaufwand.)
- Die Mitgliedsbeiträge sind nicht mehr Monats- sondern Quartalsbeiträge. Somit kann keine Rückforderung für Folgemonate erstritten werden.
- Eingezogene Mitgliedsbeiträge werden grundsätzlich nicht zurückerstattet.
- Somit ist die Finanzierung des aktuellen Quartals sichergestellt.

Detaillierte Begründung an den einzelnen Zeilen.
