### PR TITLE
Änderung der Austrittsfrist

### DIFF
--- a/Satzung.md
+++ b/Satzung.md
@@ -43,7 +43,7 @@ Im folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stan
 2. Die Mitgliedschaft beginnt mit der Aushändigung einer entsprechenden Bestätigung durch ein Vorstandsmitglied.
 
 3. Die Mitgliedschaft endet
- -	durch freiwillige Beendigung mit viermonatiger Frist zum Ende des Quartals durch schriftliche Erklärung gegenüber dem Vorstand;
+ -	durch freiwillige Beendigung mit zweiwöchiger Frist zum Ende des Monats durch schriftliche Erklärung gegenüber dem Vorstand;
  -	bei natürlichen Personen durch Tod;
  -	bei juristischen Personen mit Abschluss der Liquidation;
  -	bei Eintritt der Insolvenz des Vereins;


### PR DESCRIPTION
Die Frist zum Vereinsaustritt wird auf zwei Wochen zum Ende des Monats verkürzt.

Begründung: Die lange Austrittsfrist (mindestens drei Monate) war dadurch begründet, dass sichergestellt werden sollte, stets genügend Mittel zur Begleichung der Miete zur Verfügung zu haben. Die Kündigungsfrist des Mietvertrags beträgt 3 Monate; sollten also alle Mitglieder beschließen, aus dem Verein auszutreten, so kann bei einer sofortigen Kündigung
die Zahlung aller Mietschulden sichergestellt werden.

Inzwischen ist es dem Verein gelungen, hinreichend Rücklagen für diesen Fall zu bilden, sodass eine Absicherung über eine so ungewöhnlich lange Austrittsfrist nicht mehr notwendig ist. Die Regelung kann deshalb abgeschafft/geändert werden.

Die Beitragsordnung kann erhalten bleiben, d.h. die Beiträge werden weiterhin Quartalsweise gezahlt; Austritte sind damit zum Ende eines Quartals am sinnvollsten, aber vorher möglich.
