### PR TITLE
Alternative Änderung der Ordnungen

### DIFF
--- a/Beitrags_und_Mahnordnung.md
+++ b/Beitrags_und_Mahnordnung.md
@@ -1,20 +1,20 @@
 #Beitrags- und Mahnordnung
 *des Netz39 e.V. - Hackerspace Magdeburg*
 
-in der Fassung vom 06.05.2012
-
-Im Zuge der Gründungsversammlung am 06.05.2012 wurde die Beitrags- und Mahnordnung in der vorliegenden Fassung von der Gründungsversammlung beschlossen
+in der Fassung vom 14.10.2015.
 
 ###§1 Beitragsordnung
-1. Der Mitgliedsbeitrag ist jeweils zum Beginn eines Quartals für das gesamte Quartal im Voraus zu entrichten oder kann per Lastschriftverfahren eingezogen werden.
+1. Der Mitgliedsbeitrag ist jeweils zum Beginn eines Kalenderquartals für das gesamte Quartal im Voraus zu entrichten oder kann per Lastschriftverfahren eingezogen werden.
 
-2. Für den Beitritt wird eine Beitrittsgebühr in Höhe von 10,00 € erhoben, die mit dem ersten Beitrag fällig wird.
+2. Im Falle eines Beitritts innerhalb eines Quartals, wird eine Ermäßigung des Quartalsbeitrages gewährt. Diese beträgt für jeden bereits abgelaufenen Kalendermonat des aktuellen Quartals ein Drittel des Quartalsbeitrages.
 
-3. Der Monatsbeitrag beträgt für aktive Mitglieder 30,00 €.
+3. Für den Beitritt wird eine Beitrittsgebühr in Höhe von 10,00 € erhoben, die mit dem ersten Beitrag fällig wird.
 
-4. Auf Wunsch eines Mitglieds wird ein ermäßigter Beitragssatz in Höhe von 10,00€ pro Monat gewährt. Dieser Wunsch kann jederzeit beim Schatzmeister für ein Kalenderjahr angezeigt werden. Alle Mitglieder sind angehalten, diese Regelung nur im Bedarfsfall zu nutzen.
+4. Der Quartalsbeitrag beträgt für aktive Mitglieder 90,00 €.
 
-5. Der Beitrag für Fördermitglieder wird individuell vom Vorstand mit den jeweiligen Fördermitgliedern ausgehandelt und auf der nächsten Mitgliederversammlung bestätigt. Bei natürlichen Personen dienen Abs. 3 und Abs. 4 als Richtlinie.
+5. Auf Wunsch eines Mitglieds wird ein ermäßigter Beitragssatz in Höhe von 30,00 € pro Quartal gewährt. Dieser Wunsch kann rechtzeitig vor Beginn eines Quartals beim Schatzmeister für ein Kalenderjahr angezeigt werden. Alle Mitglieder sind angehalten, diese Regelung nur im Bedarfsfall zu nutzen.
+
+6. Der Beitrag für Fördermitglieder wird individuell vom Vorstand mit den jeweiligen Fördermitgliedern ausgehandelt und auf der nächsten Mitgliederversammlung bestätigt. Bei natürlichen Personen dienen Abs. 3 und Abs. 4 als Richtlinie.
 
 ###§2 Mahnordnung
 1. Zwei Wochen nach dem Zahlungstermin (1. Tag des jeweiligen Quartals) des fälligen Mitgliedsbeitrags erfolgt eine Zahlungserinnerung unter Angabe des Zahlungsziels.

--- a/Satzung.md
+++ b/Satzung.md
@@ -1,11 +1,11 @@
 #Satzung
 *des Netz39 e.V. - Hackerspace Magdeburg*
 
-in der Fassung vom 24.01.2013
+in der Fassung vom 14.10.2015
 
 Präambel
 --------
-Im folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stand vom 24.01.2013. In diesem Dokument wird der Einfachheit halber ein generisches Maskulinum (z.B. "ein Mitglied") verwendet. Damit sind jedoch stets alle Geschlechter gemeint. An Stellen, an denen schriftliche Kommunikation gefordert wird, ist E-Mail stets mit eingeschlossen.
+Im folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stand vom 14.10.2015. In diesem Dokument wird der Einfachheit halber ein generisches Maskulinum (z.B. "ein Mitglied") verwendet. Damit sind jedoch stets alle Geschlechter gemeint. An Stellen, an denen schriftliche Kommunikation gefordert wird, ist E-Mail stets mit eingeschlossen.
 
 ￼￼Vereinssatzung
 --------------
@@ -43,7 +43,7 @@ Im folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stan
 2. Die Mitgliedschaft beginnt mit der Aushändigung einer entsprechenden Bestätigung durch ein Vorstandsmitglied.
 
 3. Die Mitgliedschaft endet
- -	durch freiwillige Beendigung mit viermonatiger Frist zum Ende des Quartals durch schriftliche Erklärung gegenüber dem Vorstand;
+ -	durch freiwillige Beendigung ohne Frist durch schriftliche Erklärung gegenüber dem Vorstand;
  -	bei natürlichen Personen durch Tod;
  -	bei juristischen Personen mit Abschluss der Liquidation;
  -	bei Eintritt der Insolvenz des Vereins;


### PR DESCRIPTION
### Änderung in Beitrags- und Mahnordnung
- Ich empfinde es als Unfair gegenüber den bestehenden Mitgliedern, dass es andere (Neu-)Mitglieder gibt, die keinen Mitgliedsbeitrag entrichtet. 
- Diese Änderung soll bewirken, dass für jeden Restmonat eines Quartals ein Drittel (alter Monatsbeitrag) entrichtet wird.
### Änderung in der Satzung

Wie in Vorschlag von René:
- Also ähnlich wie die alte Regelung, nur dass der Austritt des Mitglieds bei nächster Gelegenheit durch den Vorstand vollzogen werden kann. 
- Damit enden die Rechte und Pflichten des Mitglieds gegenüber dem Verein und umgekehrt. 

Vorteile:
- Das Austritts-willige Mitglied ist sofort entlassen.
- Der Verwaltungsakt kann durch den Vorstand sofort durchgeführt werden. Der Mitgliedsbeitrag bleibt beim Verein.
