### PR TITLE
Fix page formatting

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -297,7 +297,7 @@ Im Folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stan
 	\end{enumerate}
 }
 
-\vspace{1.0em}
+\newpage
 
 \textbf{§14 Auflösung des Vereins}
 {\small
@@ -308,7 +308,7 @@ Im Folgenden finden sich Satzungen und Ordnungen des Vereins Netz39 auf dem Stan
 	\end{enumerate}
 }
 
-\newpage
+\vspace{1.0em}
 
 \textbf{§15 Mitgliedschaft in anderen Vereinen}
 {\small


### PR DESCRIPTION
Aktuell steht der Titel von §14 alleine auf einer Seite und dessen Absätze erst auf der nächsten Seite.
Anschließend ist die restliche Seite leer und erst auf der nächsten Seite kommt §15 und §16:

<img width="1023" height="889" alt="grafik" src="https://github.com/user-attachments/assets/74087ddc-061b-4bc6-a45a-6544a69247a7" />

Das wurde gefixt